### PR TITLE
Remove references to the Planning Council.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,14 @@
 # ChangeLog
 
+## [2020] - 2020-01-20
+
+### Removed
+- All references to the Eclipse Planning Council have been removed
+- The entire section 4.8, which quoted text from the bylaws regarding councils has been removed (the "Terms" section covers this)
+
+### Changes
+- A reference to the bylaws was added in the definition of the Eclipse Architecture Council.
+
 ## [2018] - 2018-12-14
 
 ### Added

--- a/source/development_process.adoc
+++ b/source/development_process.adoc
@@ -236,17 +236,7 @@ Committers are responsible for proactively reporting problems in the bug trackin
 Committer, PMC lead or member, Project Lead, and council representative(s) are roles; an individual may take on more than one of these roles simultaneously.
 
 [#4_8_Councils]
-=== 4.8 Councils
-
-The councils defined in the bylaws, section VII are comprised of strategic members and PMC representatives. The councils help guide the Projects as follows:
-
-____
-The Planning Council is responsible for establishing a Platform Release Plan in the form of a coordinated simultaneous Release (a.k.a, "the Release train"). The Planning Council is further responsible for cross-Project planning, architectural issues, user interface conflicts, and all other coordination and integration issues. The Planning Council discharges its responsibility via collaborative evaluation, prioritization, and compromise.
-____
-
-____
-The Architecture Council is responsible for (i) monitoring, guiding, and influencing the software architectures used by Projects, (ii) new Project mentoring, and (iii) maintaining and revising the Eclipse Development Process. Membership in the Architecture Council is per the bylaws through strategic membership, PMCs, and by appointment. The Architecture Council will, at least annually, recommend to the EMO(ED), Eclipse Members who have sufficient experience, wisdom, and time to be appointed to the Architecture Council and serve as mentors. Election as a mentor is a highly visible confirmation of the Eclipse community's respect for the candidate's technical vision, good judgement, software development skills, past and future contributions to Eclipse. It is a role that should be neither given nor taken lightly. Appointed members of the Architecture Council are appointed to two year renewable terms; renewal is based on continued participation in mentoring or other council business.
-____
+=== 4.8 [Reserved]
 
 [#4_9_Incubators]
 === 4.9 Permanent Incubator Projects

--- a/source/development_process.adoc
+++ b/source/development_process.adoc
@@ -10,7 +10,7 @@
 [[edp]]
 = Eclipse Development Process
 
-Version 1.8. Effective December 14, 2018
+Version 1.9. Effective March 24, 2020
 
 toc::[]
 

--- a/source/terms.adoc
+++ b/source/terms.adoc
@@ -4,7 +4,7 @@ Adopter ::
 Adopters are the individuals and organizations that adopt Eclipse technology for inclusion in their own products and services.
 
 Architecture Council ::
-The Eclipse Architecture Council (AC) is a council of experienced Eclipse committers responsible for identifying and tackling any issues that hinder continued technological success and innovation, widespread adoption, and future growth of Eclipse technology.
+The Eclipse Architecture Council (AC) is a council of experienced Eclipse committers responsible for identifying and tackling any issues that hinder continued technological success and innovation, widespread adoption, and future growth of Eclipse technology. The Eclipse Architecture Council is formally defined in section VII of the Bylaws of the Eclipse Foundation.
 
 Board of Directors ::
 The business and technical affairs of the Eclipse Foundation are managed by or under the direction of the Eclipse Board of Directors. 
@@ -28,7 +28,7 @@ Ecosystem ::
 An Ecosystem is a system in which companies, organizations, and individuals all work together for mutual benefit.
 
 Eclipse Management Organization ::
-The Eclipse Management Organization (EMO) consists of the Eclipse Foundation staff, and the Eclipse Architecture and Planning Councils. 
+The Eclipse Management Organization (EMO) consists of the Eclipse Foundation staff, and the Eclipse Architecture Council. 
 
 Graduation Review ::
 A Graduation Review is a type of Review that marks a Project's transition from the Incubation Phase to the Mature Phase.
@@ -65,9 +65,6 @@ A Permanent Incubator is a Project that is intended to perpetually remain in the
 
 Phase ::
 A Phase is a stage in the Project lifecycle. See Pre-proposal Phase, Proposal Phase, Incubation Phase, and Mature Phase.
-
-Planning Council ::
-The Eclipse Planning Council is a council that is responsible for cross-project planning, user interface conflicts, and all other coordination and integration issues.
 
 Pre-proposal Phase ::
 The Pre-proposal Phase is a Phase during which a new Project Proposal is created. 


### PR DESCRIPTION
The Planning Council was removed from the Bylaws of the Eclipse
Foundation in the 2020 update.